### PR TITLE
Add milestone total test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Payment Data
+
+This repository stores milestone information in `milestones.json`.
+
+## Running tests
+
+Use Python's built-in unittest runner:
+
+```bash
+python -m unittest
+```

--- a/tests/test_milestone_totals.py
+++ b/tests/test_milestone_totals.py
@@ -1,0 +1,20 @@
+import json
+import os
+import unittest
+
+class TestMilestoneTotals(unittest.TestCase):
+    def test_totals_match(self):
+        root = os.path.dirname(os.path.dirname(__file__))
+        path = os.path.join(root, 'milestones.json')
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        for contract in data.get('contracts', []):
+            with self.subTest(contract=contract.get('name')):
+                total = contract.get('total', 0)
+                sum_amounts = sum(m.get('amount', 0) for m in contract.get('milestones', []))
+                # Use tolerance for floating point arithmetic
+                self.assertAlmostEqual(sum_amounts, total, places=2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add instructions on running tests
- add milestone total test using unittest

## Testing
- `python -m unittest -v` *(fails: test_totals_match (contract='Auto Motion Works'))*

------
https://chatgpt.com/codex/tasks/task_e_684366bd811883208235c55bc7b8c14a